### PR TITLE
Rename when/css methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.6.3
+
+* Rename when/unless methods and add them to `Css`
+
 ## 0.6.2
 
 * Protected cprops.

--- a/common/src/main/scala/react/common/style/package.scala
+++ b/common/src/main/scala/react/common/style/package.scala
@@ -47,14 +47,14 @@ package style {
         s
       }
 
-    def when(pred: Boolean): js.UndefOr[Style] =
+    def when_(pred: => Boolean): js.UndefOr[Style] =
       if (pred) {
         s
       } else {
         js.undefined
       }
 
-    def unless(pred: Boolean): js.UndefOr[Style] =
+    def unless_(pred: => Boolean): js.UndefOr[Style] =
       if (pred) {
         js.undefined
       } else {
@@ -107,6 +107,20 @@ package style {
     */
   final case class Css(htmlClasses: List[String]) {
     val htmlClass: String = htmlClasses.mkString(" ")
+
+    def when_(pred: => Boolean): js.UndefOr[Css] =
+      if (pred) {
+        this
+      } else {
+        js.undefined
+      }
+
+    def unless_(pred: => Boolean): js.UndefOr[Css] =
+      if (pred) {
+        js.undefined
+      } else {
+        this
+      }
   }
 
   object Css {

--- a/test/src/test/scala/react/common/StyleTests.scala
+++ b/test/src/test/scala/react/common/StyleTests.scala
@@ -23,12 +23,16 @@ object StyleTests extends TestSuite with TestUtils {
       assert(a.remove("height").extract[String]("height").isEmpty)
     }
     test("when") {
-      assert(Style(Map("height" -> 42, "background" -> "black")).when(true).nonEmpty)
-      assert(Style(Map("height" -> 42, "background" -> "black")).when(false).isEmpty)
+      assert(Style(Map("height" -> 42, "background" -> "black")).when_(true).nonEmpty)
+      assert(Style(Map("height" -> 42, "background" -> "black")).when_(false).isEmpty)
+      assert(Css("selector").when_(true).nonEmpty)
+      assert(Css("selector").when_(false).isEmpty)
     }
     test("unless") {
-      assert(Style(Map("height" -> 42, "background" -> "black")).unless(true).isEmpty)
-      assert(Style(Map("height" -> 42, "background" -> "black")).unless(false).nonEmpty)
+      assert(Style(Map("height" -> 42, "background" -> "black")).unless_(true).isEmpty)
+      assert(Style(Map("height" -> 42, "background" -> "black")).unless_(false).nonEmpty)
+      assert(Css("selector").unless_(true).isEmpty)
+      assert(Css("selector").unless_(false).nonEmpty)
     }
   }
 }


### PR DESCRIPTION
We need when/unless methods in `Css`. The methods are renamed or they collide with `scalajs-react`