### PR TITLE
Component conversions to js.UndefOr[VdomNode]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.7.1
+
+* Automatic conversions of components to js.UndefOr[Vdom]
+
 ## 0.7.0
 
 * API changes to css and styles

--- a/common/src/main/scala/react/common/syntax/package.scala
+++ b/common/src/main/scala/react/common/syntax/package.scala
@@ -204,6 +204,46 @@ package syntax {
       p: GenericComponentPAC[P, _]
     ): VdomNode =
       p.render
+
+    implicit def ugFnProps2VdomNodeP[P <: js.Object](
+      p: GenericFnComponentP[P]
+    ): js.UndefOr[VdomNode] =
+      p.render: VdomNode
+
+    implicit def ugFnProps2VdomNodePC[P <: js.Object](
+      p: GenericFnComponentPC[P, _]
+    ): js.UndefOr[VdomNode] =
+      p.render: VdomNode
+
+    implicit def ugProps2VdomNodePA[P <: js.Object](
+      p: GenericFnComponentPA[P, _]
+    ): js.UndefOr[VdomNode] =
+      p.render: VdomNode
+
+    implicit def ugFnProps2VdomNodePAC[P <: js.Object](
+      p: GenericFnComponentPAC[P, _]
+    ): js.UndefOr[VdomNode] =
+      p.render: VdomNode
+
+    implicit def ugProps2VdomNodeP[P <: js.Object](
+      p: GenericComponentP[P]
+    ): js.UndefOr[VdomNode] =
+      p.render: VdomNode
+
+    implicit def ugProps2VdomNodePC[P <: js.Object](
+      p: GenericComponentPC[P, _]
+    ): js.UndefOr[VdomNode] =
+      p.render: VdomNode
+
+    implicit def ugProps2VdomNodePA[P <: js.Object](
+      p: GenericComponentPA[P, _]
+    ): js.UndefOr[VdomNode] =
+      p.render: VdomNode
+
+    implicit def ugProps2VdomNodePAC[P <: js.Object](
+      p: GenericComponentPAC[P, _]
+    ): js.UndefOr[VdomNode] =
+      p.render: VdomNode
     // End VdomNode conversions
   }
 }


### PR DESCRIPTION
This would let simplify some code bits, e.g. `Popup` on `scalajs-react-semanticui`