### PR TITLE
Fix Scala components, simplify logic, add tests.

### DIFF
--- a/common/src/main/scala/react/common/package.scala
+++ b/common/src/main/scala/react/common/package.scala
@@ -9,6 +9,7 @@ import japgolly.scalajs.react.component.Js.UnmountedWithRawType
 import japgolly.scalajs.react.vdom.TagMod
 import scala.scalajs.js
 import react.common.syntax.AllSyntax
+import japgolly.scalajs.react.component.Scala
 
 package object common extends AllSyntax {
 
@@ -48,7 +49,19 @@ package object common extends AllSyntax {
   @inline implicit def props2Component[Props, CT[-p, +u] <: CtorType[p, u]](
     p: ReactRender[Props, CT]
   ): VdomElement =
-    p.toVdomElement
+    p.toUnmounted
+
+  implicit class PropsWithChildren2Component[Props, CT[-p, +u] <: CtorType[p, u]](
+    p:  ReactRender[Props, CT]
+  )(implicit
+    ev: CT[Props, Scala.Unmounted[Props, _, _]] <:< CtorType.PropsAndChildren[
+      Props,
+      Scala.Unmounted[Props, _, _]
+    ]
+  ) {
+    @inline def apply(first: CtorType.ChildArg, rest: CtorType.ChildArg*): VdomElement =
+      p(first, rest: _*)
+  }
   // End Scala Components
 
   // Begin JS Components

--- a/common/src/main/scala/react/common/scalaComponents.scala
+++ b/common/src/main/scala/react/common/scalaComponents.scala
@@ -2,139 +2,87 @@ package react.common
 
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala
-import japgolly.scalajs.react.vdom.VdomElement
 import scalajs.js
 
 sealed trait ReactRender[Props, CT[-p, +u] <: CtorType[p, u]] {
-  type R
-
   protected[common] val props: Props
 
-  val render: Props => R
+  val ctor: CT[Props, Scala.Unmounted[Props, _, _]]
 
-  val toVdomElement: VdomElement
-}
-sealed trait PropsRender[Props]            extends ReactRender[Props, CtorType.Props]            {
-  override type R = VdomElement
+  @inline def apply(
+    first: CtorType.ChildArg,
+    rest:  CtorType.ChildArg*
+  )(implicit
+    ev:    CT[Props, Scala.Unmounted[Props, _, _]] <:< CtorType.PropsAndChildren[
+      Props,
+      Scala.Unmounted[Props, _, _]
+    ]
+  ): Scala.Unmounted[Props, _, _] =
+    ctor.applyGeneric(props)((first +: rest): _*)
 
-  override lazy val toVdomElement: VdomElement = render(props)
-}
-sealed trait PropsAndChildrenRender[Props] extends ReactRender[Props, CtorType.PropsAndChildren] {
-  override type R = CtorType.ChildrenArgs => VdomElement
-
-  override lazy val toVdomElement: VdomElement = render(props)(Seq.empty)
-
-  @inline def apply(first: CtorType.ChildArg, rest: CtorType.ChildArg*): VdomElement =
-    render(props)(first +: rest)
-
+  @inline val toUnmounted: Scala.Unmounted[Props, _, _] = ctor.applyGeneric(props)()
 }
 
-trait ReactComponentProps[Props, CT[-p, +u] <: CtorType[p, u]] extends ReactRender[Props, CT] {
-  val component: Scala.Component[Props, _, _, CT]
+sealed trait CtorWithProps[Props, CT[-p, +u] <: CtorType[p, u]] extends ReactRender[Props, CT] {
+  protected type CopyType[-P, +U] = ctor.This[P, U]
+  protected type CopyTypePU       =
+    CopyType[Props, Scala.Unmounted[Props, _, _]]
 
-  protected[common] val props: Props = this.asInstanceOf[Props]
-
-  type UnmountedType[-P, +U] =
-    CT[P, U]#This[P, U]
-  type UnmountedTypePU       =
-    UnmountedType[Props, Scala.Unmounted[Props, _, _]]
-
-  private def toUnmounted(
-    newUnmounted: UnmountedTypePU
-  ): UnmountedReactComponentProps[Props, UnmountedType] =
-    new UnmountedReactComponentProps[Props, UnmountedType] {
-      type R = ReactComponentProps.this.R
-
-      override val unmounted               = newUnmounted
-      override protected[common] val props = ReactComponentProps.this.props
-      @inline override val render          = ReactComponentProps.this.render
-      @inline override val toVdomElement   = ReactComponentProps.this.toVdomElement
+  protected def copy(
+    newCtor: CopyTypePU
+  ): CtorWithProps[Props, CopyType] =
+    new CtorWithProps[Props, CopyType] {
+      override lazy val ctor                    = newCtor
+      override protected[common] lazy val props = CtorWithProps.this.props
     }
 
   def withKey(key: Key) =
-    toUnmounted(component.withKey(key))
+    copy(ctor.withKey(key))
 
   final def withKey(k: Long) =
-    toUnmounted(component.withKey(k))
+    copy(ctor.withKey(k))
 
   def addMod(f: CtorType.ModFn) =
-    toUnmounted(component.addMod(f))
+    copy(ctor.addMod(f))
 
   final def withRawProp(name: String, value: js.Any) =
-    toUnmounted(component.withRawProp(name, value))
+    copy(ctor.withRawProp(name, value))
+}
 
-  private def copy(
+sealed trait ReactComponentProps[Props, CT[-p, +u] <: CtorType[p, u]]
+    extends CtorWithProps[Props, CT] {
+  val component: Scala.Component[Props, _, _, CT]
+
+  protected[common] lazy val props: Props = this.asInstanceOf[Props]
+
+  override lazy val ctor: CT[Props, Scala.Unmounted[Props, _, _]] = component.ctor
+
+  private def copyComponent(
     newComponent: Scala.Component[Props, _, _, CT]
   ): ReactComponentProps[Props, CT] =
     new ReactComponentProps[Props, CT] {
-      type R = ReactComponentProps.this.R
-
-      override val component               = newComponent
-      override protected[common] val props = ReactComponentProps.this.props
-      @inline override val render          = ReactComponentProps.this.render
-      @inline override val toVdomElement   = ReactComponentProps.this.toVdomElement
+      override lazy val component               = newComponent
+      override protected[common] lazy val props = ReactComponentProps.this.props
     }
 
   def withRef[S, B](ref: Ref.Handle[ScalaComponent.RawMounted[Props, S, B]]) =
-    copy(
-      ReactComponentProps.this.component
+    copyComponent(
+      component
         .asInstanceOf[Scala.Component[Props, S, B, CT]]
         .withRef(ref)
     )
 
   def withOptionalRef[S, B](ref: Option[Ref.Handle[ScalaComponent.RawMounted[Props, S, B]]]) =
-    copy(
-      ReactComponentProps.this.component
+    copyComponent(
+      component
         .asInstanceOf[Scala.Component[Props, S, B, CT]]
         .withOptionalRef(ref)
     )
 }
 
-trait UnmountedReactComponentProps[Props, CT[-p, +u] <: CtorType[p, u]]
-    extends ReactRender[Props, CT] {
-  val unmounted: CT[Props, Scala.Unmounted[Props, _, _]]
-
-  protected[common] val props: Props
-
-  type CopyType[-P, +U] =
-    UnmountedReactComponentProps.this.unmounted.This[P, U]
-  type CopyTypePU       =
-    CopyType[Props, Scala.Unmounted[Props, _, _]]
-
-  private def copy(
-    newUnmounted: CopyTypePU
-  ): UnmountedReactComponentProps[Props, CopyType] =
-    new UnmountedReactComponentProps[Props, CopyType] {
-      type R = UnmountedReactComponentProps.this.R
-
-      override val unmounted               = newUnmounted
-      override protected[common] val props = UnmountedReactComponentProps.this.props
-      @inline override val render          = UnmountedReactComponentProps.this.render
-      @inline override val toVdomElement   = UnmountedReactComponentProps.this.toVdomElement
-    }
-
-  def withKey(key: Key) =
-    copy(UnmountedReactComponentProps.this.unmounted.withKey(key))
-
-  final def withKey(k: Long) =
-    copy(UnmountedReactComponentProps.this.unmounted.withKey(k))
-
-  def addMod(f: CtorType.ModFn) =
-    copy(UnmountedReactComponentProps.this.unmounted.addMod(f))
-
-  final def withRawProp(name: String, value: js.Any) =
-    copy(UnmountedReactComponentProps.this.unmounted.withRawProp(name, value))
-}
-
 class ReactProps[Props](val component: Scala.Component[Props, _, _, CtorType.Props])
     extends ReactComponentProps[Props, CtorType.Props]
-    with PropsRender[Props] {
-  override lazy val render: Props => VdomElement = component.apply
-}
 
 class ReactPropsWithChildren[Props](
   val component: Scala.Component[Props, _, _, CtorType.PropsAndChildren]
 ) extends ReactComponentProps[Props, CtorType.PropsAndChildren]
-    with PropsAndChildrenRender[Props] {
-  override lazy val render: Props => CtorType.ChildrenArgs => VdomElement = component.apply
-}

--- a/test/src/test/scala/react/common/ScalaComponentTests.scala
+++ b/test/src/test/scala/react/common/ScalaComponentTests.scala
@@ -1,0 +1,195 @@
+package react.common
+
+import japgolly.scalajs.react.test._
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.Ref
+import japgolly.scalajs.react.ScalaComponent
+import utest._
+
+object ScalaComponentTests extends TestSuite {
+
+  case class Props() extends ReactProps[Props](propsComponent)
+
+  case class PropsWithChildren()
+      extends ReactPropsWithChildren[PropsWithChildren](propsWithChildrenComponent)
+
+  val propsComponent =
+    ScalaComponent.builder[Props].render(_ => <.div).build
+
+  val propsWithChildrenComponent =
+    ScalaComponent.builder[PropsWithChildren].render_C(c => <.div(c)).build
+
+  val tests = Tests {
+    test("props") {
+      val p        = Props()
+      val u        = p.toUnmounted
+      val key      = u.key
+      val ref      = u.ref
+      val props    = u.props
+      val children = u.propsChildren
+      assert(key == None)
+      assert(ref == None)
+      assert(props == Props())
+      assert(children.toList == List.empty)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        p.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div></div>""")
+      }
+    }
+
+    test("props.withKey") {
+      val p        = Props().withKey("key")
+      val u        = p.toUnmounted
+      val key      = u.key
+      val ref      = u.ref
+      val props    = u.props
+      val children = u.propsChildren
+      assert(key == Some("key"))
+      assert(ref == None)
+      assert(props == Props())
+      assert(children.toList == List.empty)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        p.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div></div>""")
+      }
+    }
+
+    test("props.withRef") {
+      val p        = Props()
+      val r        = Ref.toScalaComponent(p.component)
+      val pr       = p.withRef(r)
+      val u        = pr.toUnmounted
+      val key      = u.key
+      val ref      = u.ref
+      val props    = u.props
+      val children = u.propsChildren
+      assert(key == None)
+      assert(ref == Some(r.raw.asInstanceOf[japgolly.scalajs.react.raw.React.RefHandle[Any]]))
+      assert(props == Props())
+      assert(children.toList == List.empty)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        pr.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div></div>""")
+      }
+    }
+
+    test("props.withRef.withKey") {
+      val p        = Props()
+      val r        = Ref.toScalaComponent(p.component)
+      val pr       = p.withRef(r).withKey("key")
+      val u        = pr.toUnmounted
+      val key      = u.key
+      val ref      = u.ref
+      val props    = u.props
+      val children = u.propsChildren
+      assert(key == Some("key"))
+      assert(ref == Some(r.raw.asInstanceOf[japgolly.scalajs.react.raw.React.RefHandle[Any]]))
+      assert(props == Props())
+      assert(children.toList == List.empty)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        pr.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div></div>""")
+      }
+    }
+
+    test("propsWithChildren") {
+      val p        = PropsWithChildren()
+      val u        = p(<.div)
+      val key      = u.key
+      val ref      = u.ref
+      val props    = u.props
+      val children = u.propsChildren
+      assert(key == None)
+      assert(ref == None)
+      assert(props == PropsWithChildren())
+      assert(children.count == 1)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        p.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div></div>""")
+      }
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        u.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div><div></div></div>""")
+      }
+    }
+
+    test("propsWithChildren.withKey") {
+      val p        = PropsWithChildren().withKey("key")
+      val u        = p(<.div)
+      val key      = u.key
+      val ref      = u.ref
+      val props    = u.props
+      val children = u.propsChildren
+      assert(key == Some("key"))
+      assert(ref == None)
+      assert(props == PropsWithChildren())
+      assert(children.count == 1)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        p.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div></div>""")
+      }
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        u.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div><div></div></div>""")
+      }
+    }
+
+    test("propsWithChildren.withRef") {
+      val p        = PropsWithChildren()
+      val r        = Ref.toScalaComponent(p.component)
+      val pr       = p.withRef(r)
+      val u        = pr(<.div)
+      val key      = u.key
+      val ref      = u.ref
+      val props    = u.props
+      val children = u.propsChildren
+      assert(key == None)
+      assert(ref == Some(r.raw.asInstanceOf[japgolly.scalajs.react.raw.React.RefHandle[Any]]))
+      assert(props == PropsWithChildren())
+      assert(children.count == 1)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        pr.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div></div>""")
+      }
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        u.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div><div></div></div>""")
+      }
+    }
+
+    test("propsWithChildren.withRef.withKey") {
+      val p        = PropsWithChildren()
+      val r        = Ref.toScalaComponent(p.component)
+      val pr       = p.withRef(r).withKey("key")
+      val u        = pr(<.div)
+      val key      = u.key
+      val ref      = u.ref
+      val props    = u.props
+      val children = u.propsChildren
+      assert(key == Some("key"))
+      assert(ref == Some(r.raw.asInstanceOf[japgolly.scalajs.react.raw.React.RefHandle[Any]]))
+      assert(props == PropsWithChildren())
+      assert(children.count == 1)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        pr.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div></div>""")
+      }
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        u.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div><div></div></div>""")
+      }
+    }
+  }
+}


### PR DESCRIPTION
The last change adding `withKey` and friends wasn't really working. The actual rendering function was that of the original key-less component.

Besides fixing that, this PR streamlines the logic and adds tests.