### PR TITLE
Reorganize syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ package-lock.json
 yarn.lock
 travis/secrets.tar
 .hydra/
+.bsp/

--- a/common/src/main/scala/react/common/jsComponents.scala
+++ b/common/src/main/scala/react/common/jsComponents.scala
@@ -21,7 +21,7 @@ class AttrsBuilder(p: js.Object) extends VdomBuilder.ToJs {
 
 trait GenericFnComponent[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U] {
   protected def cprops: P
-  @inline def render: Render[P]
+  @inline def render: RenderFn[P]
 }
 
 trait GenericFnComponentC[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A] {

--- a/common/src/main/scala/react/common/package.scala
+++ b/common/src/main/scala/react/common/package.scala
@@ -6,12 +6,11 @@ import japgolly.scalajs.react.vdom.VdomNode
 import japgolly.scalajs.react.component.Generic
 import japgolly.scalajs.react.component.Js.RawMounted
 import japgolly.scalajs.react.component.Js.UnmountedWithRawType
+import japgolly.scalajs.react.component.Scala
 import japgolly.scalajs.react.vdom.TagMod
 import scala.scalajs.js
-import react.common.syntax.AllSyntax
-import japgolly.scalajs.react.component.Scala
 
-package object common extends AllSyntax {
+package object common {
 
   def merge(a: js.Object, b: js.Object): js.Object = {
     val m = js.Dictionary.empty[js.Any]
@@ -113,5 +112,4 @@ package object common extends AllSyntax {
       extends AnyVal {
     def apply(modifiers: TagMod*): A = c.addModifiers(modifiers)
   }
-  // End JS Components
 }

--- a/common/src/main/scala/react/common/syntax/package.scala
+++ b/common/src/main/scala/react/common/syntax/package.scala
@@ -40,7 +40,7 @@ package syntax {
       a.map(ev.value)
   }
 
-  trait CallbackPairSyntax {
+  trait CallbackPairSyntax extends CallbackSyntax {
     implicit def syntaxCallbackPair1[A](
       a: (js.UndefOr[A => Callback], js.UndefOr[Callback])
     ): CallbackPairOps1[A] =
@@ -50,14 +50,6 @@ package syntax {
       a: (js.UndefOr[(A, B) => Callback], js.UndefOr[Callback])
     ): CallbackPairOps2[A, B] =
       new CallbackPairOps2(a._1, a._2)
-  }
-
-  final class CallbackPairOps1[A](a: js.UndefOr[A => Callback], b: js.UndefOr[Callback]) {
-    def toJs: js.UndefOr[js.Function1[A, Unit]] = a.toJs.orElse(b.toJs1)
-  }
-
-  final class CallbackPairOps2[A, B](a: js.UndefOr[(A, B) => Callback], b: js.UndefOr[Callback]) {
-    def toJs: js.UndefOr[js.Function2[A, B, Unit]] = a.toJs.orElse(b.toJs2)
   }
 
   final class VdomOps(val node: VdomNode) extends AnyVal {
@@ -81,6 +73,25 @@ package syntax {
 
   final class CallbackOps2[A, B](val c: js.UndefOr[(A, B) => Callback]) extends AnyVal {
     def toJs: js.UndefOr[js.Function2[A, B, Unit]] = c.map(x => (a: A, b: B) => x(a, b).runNow())
+  }
+
+  trait CallbackSyntax {
+    implicit def callbackOps(c: js.UndefOr[Callback]): CallbackOps =
+      new CallbackOps(c)
+
+    implicit def callbackOps1[A](c: js.UndefOr[A => Callback]): CallbackOps1[A] =
+      new CallbackOps1(c)
+
+    implicit def callbackOps2[A, B](c: js.UndefOr[(A, B) => Callback]): CallbackOps2[A, B] =
+      new CallbackOps2(c)
+
+    final class CallbackPairOps1[A](a: js.UndefOr[A => Callback], b: js.UndefOr[Callback]) {
+      def toJs: js.UndefOr[js.Function1[A, Unit]] = a.toJs.orElse(b.toJs1)
+    }
+
+    final class CallbackPairOps2[A, B](a: js.UndefOr[(A, B) => Callback], b: js.UndefOr[Callback]) {
+      def toJs: js.UndefOr[js.Function2[A, B, Unit]] = a.toJs.orElse(b.toJs2)
+    }
   }
 
   final class JsNumberOps(val d: JsNumber) extends AnyVal {
@@ -107,144 +118,146 @@ package syntax {
       }
   }
 
-  trait AllSyntax extends EnumValueSyntax with CallbackPairSyntax with style.StyleSyntax {
+  trait AllSyntax
+      extends EnumValueSyntax
+      with CallbackPairSyntax
+      with style.StyleSyntax
+      with RenderSyntax
+      with VdomSyntax {
     implicit def vdomOps(node: VdomNode): VdomOps =
       new VdomOps(node)
 
     implicit def vdomUndefOps(node: js.UndefOr[VdomNode]): VdomUndefOps =
       new VdomUndefOps(node)
 
-    implicit def callbackOps(c: js.UndefOr[Callback]): CallbackOps =
-      new CallbackOps(c)
-
-    implicit def callbackOps1[A](c: js.UndefOr[A => Callback]): CallbackOps1[A] =
-      new CallbackOps1(c)
-
-    implicit def callbackOps2[A, B](c: js.UndefOr[(A, B) => Callback]): CallbackOps2[A, B] =
-      new CallbackOps2(c)
-
     implicit def jsNumberOps(d: JsNumber): JsNumberOps =
       new JsNumberOps(d)
 
-    // Start Render(Fn) conversions
-    implicit def gFnProps2VdomP[P <: js.Object](
+  }
+
+  trait RenderSyntax {
+    // Render(Fn) conversions
+    implicit def GenericFnComponentP2RenderFn[P <: js.Object](
       p: GenericFnComponentP[P]
-    ): Render[P] =
+    ): RenderFn[P] =
       p.render
 
-    implicit def gProps2FnUnmountedPC[P <: js.Object](
+    implicit def GenericFnComponentPC2RenderFn[P <: js.Object](
       p: GenericFnComponentPC[P, _]
     ): RenderFn[P] =
       p.render
 
-    implicit def gFnProps2VdomPA[P <: js.Object](
+    implicit def GenericFnComponentPA2RenderFn[P <: js.Object](
       p: GenericFnComponentPA[P, _]
     ): RenderFn[P] =
       p.render
 
-    implicit def gProps2FnUnmountedPAC[P <: js.Object](
+    implicit def GenericFnComponentPAC2RenderFn[P <: js.Object](
       p: GenericFnComponentPAC[P, _]
     ): RenderFn[P] =
       p.render
 
-    implicit def gProps2VdomP[P <: js.Object](
+    // Render conversions
+    implicit def GenericComponentP2Render[P <: js.Object](
       p: GenericComponentP[P]
     ): Render[P] =
       p.render
 
-    implicit def gProps2UnmountedPC[P <: js.Object](
+    implicit def GenericComponentPC2Render[P <: js.Object](
       p: GenericComponentPC[P, _]
     ): Render[P] =
       p.render
 
-    implicit def gProps2VdomPA[P <: js.Object](
+    implicit def GenericComponentPA2Render[P <: js.Object](
       p: GenericComponentPA[P, _]
     ): Render[P] =
       p.render
 
-    implicit def gProps2UnmountedPAC[P <: js.Object](
+    implicit def GenericComponentPAC2Render[P <: js.Object](
       p: GenericComponentPAC[P, _]
     ): Render[P] =
       p.render
-    // End Render(Fn) conversions
+  }
 
-    // Start VdomNode conversions
-    implicit def gFnProps2VdomNodeP[P <: js.Object](
+  trait VdomSyntax    {
+    // Fn to VdomNode conversions
+    implicit def GenericFnComponentP2VdomNode[P <: js.Object](
       p: GenericFnComponentP[P]
     ): VdomNode =
       p.render
 
-    implicit def gFnProps2VdomNodePC[P <: js.Object](
+    implicit def GenericFnComponentPC2VdomNode[P <: js.Object](
       p: GenericFnComponentPC[P, _]
     ): VdomNode =
       p.render
 
-    implicit def gProps2VdomNodePA[P <: js.Object](
+    implicit def GenericFnComponentPA2VdomNode[P <: js.Object](
       p: GenericFnComponentPA[P, _]
     ): VdomNode =
       p.render
 
-    implicit def gFnProps2VdomNodePAC[P <: js.Object](
+    implicit def GenericFnComponentPAC2VdomNode[P <: js.Object](
       p: GenericFnComponentPAC[P, _]
     ): VdomNode =
       p.render
 
-    implicit def gProps2VdomNodeP[P <: js.Object](
+    // Component 2 VdomNode
+    implicit def GenericComponentP2VdomNode[P <: js.Object](
       p: GenericComponentP[P]
     ): VdomNode =
       p.render
 
-    implicit def gProps2VdomNodePC[P <: js.Object](
+    implicit def GenericComponentPC2VdomNode[P <: js.Object](
       p: GenericComponentPC[P, _]
     ): VdomNode =
       p.render
 
-    implicit def gProps2VdomNodePA[P <: js.Object](
+    implicit def GenericComponentPA2VdomNode[P <: js.Object](
       p: GenericComponentPA[P, _]
     ): VdomNode =
       p.render
 
-    implicit def gProps2VdomNodePAC[P <: js.Object](
+    implicit def GenericComponentPAC2VdomNode[P <: js.Object](
       p: GenericComponentPAC[P, _]
     ): VdomNode =
       p.render
 
-    implicit def ugFnProps2VdomNodeP[P <: js.Object](
+    implicit def GenericFnComponentP2UndefVdomNode[P <: js.Object](
       p: GenericFnComponentP[P]
     ): js.UndefOr[VdomNode] =
       p.render: VdomNode
 
-    implicit def ugFnProps2VdomNodePC[P <: js.Object](
+    implicit def GenericFnComponentPC2UndefVdomNode[P <: js.Object](
       p: GenericFnComponentPC[P, _]
     ): js.UndefOr[VdomNode] =
       p.render: VdomNode
 
-    implicit def ugProps2VdomNodePA[P <: js.Object](
+    implicit def GenericFnComponentPA2UndefVdomNode[P <: js.Object](
       p: GenericFnComponentPA[P, _]
     ): js.UndefOr[VdomNode] =
       p.render: VdomNode
 
-    implicit def ugFnProps2VdomNodePAC[P <: js.Object](
+    implicit def GenericFnComponentPAC2UndefVdomNode[P <: js.Object](
       p: GenericFnComponentPAC[P, _]
     ): js.UndefOr[VdomNode] =
       p.render: VdomNode
 
-    implicit def ugProps2VdomNodeP[P <: js.Object](
+    implicit def GenericComponentP2UndefVdomNode[P <: js.Object](
       p: GenericComponentP[P]
     ): js.UndefOr[VdomNode] =
       p.render: VdomNode
 
-    implicit def ugProps2VdomNodePC[P <: js.Object](
+    implicit def GenericComponentPC2UndefVdomNode[P <: js.Object](
       p: GenericComponentPC[P, _]
     ): js.UndefOr[VdomNode] =
       p.render: VdomNode
 
-    implicit def ugProps2VdomNodePA[P <: js.Object](
+    implicit def GenericComponentPA2UndefVdomNode[P <: js.Object](
       p: GenericComponentPA[P, _]
     ): js.UndefOr[VdomNode] =
       p.render: VdomNode
 
-    implicit def ugProps2VdomNodePAC[P <: js.Object](
+    implicit def GenericComponentPAC2UndefVdomNode[P <: js.Object](
       p: GenericComponentPAC[P, _]
     ): js.UndefOr[VdomNode] =
       p.render: VdomNode
@@ -252,4 +265,8 @@ package syntax {
   }
 }
 
-package object syntax extends AllSyntax
+package object syntax {
+  object all    extends AllSyntax
+  object vdom   extends VdomSyntax
+  object render extends RenderSyntax
+}

--- a/test/src/test/scala/react/common/CommonSuite.scala
+++ b/test/src/test/scala/react/common/CommonSuite.scala
@@ -1,6 +1,7 @@
 package react.common
 
 import react.common.implicits._
+import react.common.syntax.all._
 import cats.syntax.all._
 import scala.scalajs.js
 


### PR DESCRIPTION
It seems the upgrade to scalajs-react messed up the conversion creating some troubles downstream.
I haven't been able to pintpoint the cause but this PR seems to help splitting the syntax in a few different objects letting you selectively import some or all imports

This is a breaking change as we used to import all syntax when doing `import react.common._`