### PR TITLE
Attempt making common package extend AllSyntax.

### DIFF
--- a/common/src/main/scala/react/common/package.scala
+++ b/common/src/main/scala/react/common/package.scala
@@ -8,9 +8,10 @@ import japgolly.scalajs.react.component.Js.RawMounted
 import japgolly.scalajs.react.component.Js.UnmountedWithRawType
 import japgolly.scalajs.react.component.Scala
 import japgolly.scalajs.react.vdom.TagMod
+import react.common.syntax.AllSyntax
 import scala.scalajs.js
 
-package object common {
+package object common extends AllSyntax {
 
   def merge(a: js.Object, b: js.Object): js.Object = {
     val m = js.Dictionary.empty[js.Any]

--- a/test/src/test/scala/react/common/CommonSuite.scala
+++ b/test/src/test/scala/react/common/CommonSuite.scala
@@ -1,7 +1,6 @@
 package react.common
 
 import react.common.implicits._
-import react.common.syntax.all._
 import cats.syntax.all._
 import scala.scalajs.js
 


### PR DESCRIPTION
Somehow, reinstanting `AllSyntax` in the package object seems to work. 