### PR TITLE
Migrate to Scala 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ yarn.lock
 travis/secrets.tar
 .hydra/
 .bsp/
+.vscode/

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.0.1"
+version = "3.0.2"
 style = default
 
 maxColumn = 100

--- a/build.sbt
+++ b/build.sbt
@@ -60,25 +60,26 @@ lazy val test =
     .enablePlugins(ScalaJSPlugin)
     .settings(commonSettings: _*)
     .settings(
-      name                        := "test",
+      name                                                       := "test",
       Test / npmDependencies ++= Seq(
         "react"     -> reactJS,
         "react-dom" -> reactJS
       ),
       // Requires the DOM for tests
-      Test / requireJsDomEnv      := true,
+      Test / requireJsDomEnv                                     := true,
       // Use yarn as it is faster than npm
-      useYarn                     := true,
-      webpack / version           := "4.44.1",
-      webpackCliVersion / version := "3.3.11",
+      useYarn                                                    := true,
+      webpack / version                                          := "4.44.1",
+      (webpackCliVersion / version).withRank(KeyRanks.Invisible) := "3.3.11",
       // Compile tests to JS using fast-optimisation
-      Test / scalaJSStage         := FastOptStage,
+      Test / scalaJSStage                                        := FastOptStage,
       libraryDependencies ++= Seq(
         "org.scalameta" %%% "munit"     % "0.7.29",
         "org.typelevel" %%% "cats-core" % "2.6.1" % Test
       ),
-      Test / webpackExtraArgs     := Seq("--verbose", "--progress", "true"),
-      Test / webpackConfigFile    := Some(
+      (Test / webpackExtraArgs)
+        .withRank(KeyRanks.Invisible)                            := Seq("--verbose", "--progress", "true"),
+      Test / webpackConfigFile                                   := Some(
         baseDirectory.value / "src" / "webpack" / "test.webpack.config.js"
       ),
       scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
@@ -101,7 +102,7 @@ lazy val root = (project in file("."))
   .aggregate(common, cats, test)
 
 lazy val commonSettings = Seq(
-  scalaVersion           := "2.13.6",
+  scalaVersion           := "3.0.2",
   organization           := "io.github.cquiroz.react",
   description            := "scala.js react common utilities",
   sonatypeProfileName    := "io.github.cquiroz",

--- a/common/src/main/scala/react/common/package.scala
+++ b/common/src/main/scala/react/common/package.scala
@@ -46,17 +46,17 @@ package object common extends AllSyntax {
   type Css   = style.Css
 
   // Begin Scala Components
-  @inline implicit def props2Component[Props, CT[-p, +u] <: CtorType[p, u]](
-    p: ReactRender[Props, CT]
+  @inline implicit def props2Component[Props, S, B, CT[-p, +u] <: CtorType[p, u]](
+    p: ReactRender[Props, S, B, CT]
   ): VdomElement =
     p.toUnmounted
 
-  implicit class PropsWithChildren2Component[Props, CT[-p, +u] <: CtorType[p, u]](
-    p:  ReactRender[Props, CT]
+  implicit class PropsWithChildren2Component[Props, S, B, CT[-p, +u] <: CtorType[p, u]](
+    p:  ReactRender[Props, S, B, CT]
   )(implicit
-    ev: CT[Props, Scala.Unmounted[Props, _, _]] <:< CtorType.PropsAndChildren[
+    ev: CT[Props, Scala.Unmounted[Props, S, B]] <:< CtorType.PropsAndChildren[
       Props,
-      Scala.Unmounted[Props, _, _]
+      Scala.Unmounted[Props, S, B]
     ]
   ) {
     @inline def apply(first: CtorType.ChildArg, rest: CtorType.ChildArg*): VdomElement =

--- a/common/src/main/scala/react/common/scalaComponents.scala
+++ b/common/src/main/scala/react/common/scalaComponents.scala
@@ -4,6 +4,8 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala
 // import japgolly.scalajs.react.ReactExtensions._
 import scalajs.js
+import japgolly.scalajs.react.component.ScalaFn
+import japgolly.scalajs.react.vdom.VdomElement
 
 sealed trait ReactRender[Props, CT[-p, +u] <: CtorType[p, u]] {
   protected[common] val props: Props
@@ -87,3 +89,23 @@ class ReactProps[Props](val component: Scala.Component[Props, _, _, CtorType.Pro
 class ReactPropsWithChildren[Props](
   val component: Scala.Component[Props, _, _, CtorType.PropsAndChildren]
 ) extends ReactComponentProps[Props, CtorType.PropsAndChildren]
+
+sealed trait ReactFnComponentProps[Props, CT[-p, +u] <: CtorType[p, u]] {
+  // extends CtorWithProps[Props, CT] {
+  val component: ScalaFn.Component[Props, CT]
+
+  protected[common] lazy val props: Props = this.asInstanceOf[Props]
+}
+
+class ReactFnProps[Props](val component: ScalaFn.Component[Props, CtorType.Props])
+    extends ReactFnComponentProps[Props, CtorType.Props]
+
+object ReactFnProps {
+  implicit def render[Props, CT[-p, +u] <: CtorType[p, u]](
+    props: ReactFnComponentProps[Props, CT]
+  ): VdomElement = props.component.applyGeneric(props.props)().vdomElement
+}
+
+class ReactFnPropsWithChildren[Props](
+  val component: ScalaFn.Component[Props, CtorType.PropsAndChildren]
+) extends ReactFnComponentProps[Props, CtorType.PropsAndChildren]

--- a/test/src/test/scala/react/common/ScalaComponentsSuite.scala
+++ b/test/src/test/scala/react/common/ScalaComponentsSuite.scala
@@ -7,10 +7,9 @@ import japgolly.scalajs.react.ScalaComponent
 
 class ScalaComponentSuite extends munit.FunSuite {
 
-  case class Props() extends ReactProps[Props](propsComponent)
+  case class Props() extends ReactProps(propsComponent)
 
-  case class PropsWithChildren()
-      extends ReactPropsWithChildren[PropsWithChildren](propsWithChildrenComponent)
+  case class PropsWithChildren() extends ReactPropsWithChildren(propsWithChildrenComponent)
 
   val propsComponent =
     ScalaComponent.builder[Props].render(_ => <.div).build

--- a/test/src/test/scala/react/common/StyleSuite.scala
+++ b/test/src/test/scala/react/common/StyleSuite.scala
@@ -2,6 +2,7 @@ package react.common
 
 import cats.syntax.all._
 import react.common.implicits._
+import react.common.style._
 
 class StyleSuite extends munit.FunSuite with TestUtils {
   test("style") {


### PR DESCRIPTION
Lacking existential types, we have to pass around `S` and `B` types everywhere, but on the other hand Scala 3 can correctly infer these (and `Props`) where Scala 2 couldn't break cyclic dependencies.

For the moment syntax is not migrated (`using`, `given`, no braces, etc.).

