### PR TITLE
JS components: add .withRef and allow facades.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ yarn.lock
 travis/secrets.tar
 .hydra/
 .bsp/
+.vscode/

--- a/common/src/main/scala/react/common/jsComponents.scala
+++ b/common/src/main/scala/react/common/jsComponents.scala
@@ -1,6 +1,7 @@
 package react.common
 
 import japgolly.scalajs.react.CtorType
+import japgolly.scalajs.react.Ref
 import japgolly.scalajs.react.vdom.VdomNode
 import japgolly.scalajs.react.component.Js
 import japgolly.scalajs.react.component.JsFn
@@ -75,37 +76,225 @@ trait GenericFnComponentAC[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
   }
 }
 
-trait GenericJsComponent[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U] {
+trait GenericJsComponent[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U] { self =>
   protected def cprops: P
-  def rawProps: P = cprops
-  @inline def render: Render[P]
+  protected val component: Js.Component[P, Null, CT]
+
+  def rawProps: P               = cprops
+  @inline def render: Render[P] = component.applyGeneric(rawProps)()
+
+  private def copyComponent(
+    newComponent: Js.Component[P, Null, CT]
+  ): GenericJsComponent[P, CT, U] =
+    new GenericJsComponent[P, CT, U] {
+      override protected def cprops: P = self.cprops
+      override protected val component = newComponent
+    }
+
+  def withRef(ref: Ref.Handle[Js.RawMounted[P, Null]]): GenericJsComponent[P, CT, U] =
+    copyComponent(self.component.withRef(ref))
+
+  def withOptionalRef(
+    ref: Option[Ref.Handle[Js.RawMounted[P, Null]]]
+  ): GenericJsComponent[P, CT, U] =
+    copyComponent(self.component.withOptionalRef(ref))
 }
 
-trait GenericJsComponentC[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A] {
+trait GenericJsComponentC[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A] { self =>
   protected def cprops: P
   val children: CtorType.ChildrenArgs
   def withChildren(children: CtorType.ChildrenArgs): A
+  protected val component: Js.Component[P, Null, CT]
 
-  def rawProps: P               = cprops
-  @inline def renderWith: RenderC[P]
-  @inline def render: Render[P] = renderWith(children)
+  def rawProps: P                    = cprops
+  @inline def renderWith: RenderC[P] = component.applyGeneric(rawProps)
+  @inline def render: Render[P]      = renderWith(children)
+
+  private def copyComponent(
+    newComponent: Js.Component[P, Null, CT]
+  ): GenericJsComponentC[P, CT, U, A] =
+    new GenericJsComponentC[P, CT, U, A] {
+      override protected def cprops: P = self.cprops
+      override val children            = self.children
+      override def withChildren(children: CtorType.ChildrenArgs): A = self.withChildren(children)
+      override protected val component = newComponent
+    }
+
+  def withRef(ref: Ref.Handle[Js.RawMounted[P, Null]]): GenericJsComponentC[P, CT, U, A] =
+    copyComponent(self.component.withRef(ref))
+
+  def withOptionalRef(
+    ref: Option[Ref.Handle[Js.RawMounted[P, Null]]]
+  ): GenericJsComponentC[P, CT, U, A] =
+    copyComponent(self.component.withOptionalRef(ref))
 }
 
 trait GenericJsComponentA[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
-    extends PassthroughA[P] {
-  protected val component: Js.ComponentWithRawType[P, Null, Js.RawMounted[P, Null], CT]
+    extends PassthroughA[P] { self =>
+  protected val component: Js.Component[P, Null, CT]
   def addModifiers(modifiers: Seq[TagMod]): A
 
   @inline def render: Render[P] = component.applyGeneric(rawProps)()
+
+  private def copyComponent(
+    newComponent: Js.Component[P, Null, CT]
+  ): GenericJsComponentA[P, CT, U, A] =
+    new GenericJsComponentA[P, CT, U, A] {
+      override protected def cprops: P                                = self.cprops
+      override val modifiers: Seq[japgolly.scalajs.react.vdom.TagMod] = self.modifiers
+      override protected val component                                = newComponent
+      override def addModifiers(modifiers: Seq[TagMod]): A = self.addModifiers(modifiers)
+    }
+
+  def withRef(ref: Ref.Handle[Js.RawMounted[P, Null]]): GenericJsComponentA[P, CT, U, A] =
+    copyComponent(self.component.withRef(ref))
+
+  def withOptionalRef(
+    ref: Option[Ref.Handle[Js.RawMounted[P, Null]]]
+  ): GenericJsComponentA[P, CT, U, A] =
+    copyComponent(self.component.withOptionalRef(ref))
 }
 
 trait GenericJsComponentAC[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
-    extends PassthroughAC[P] {
-  protected val component: Js.ComponentWithRawType[P, Null, Js.RawMounted[P, Null], CT]
+    extends PassthroughAC[P] { self =>
+  protected val component: Js.Component[P, Null, CT]
   def addModifiers(modifiers: Seq[TagMod]): A
 
   @inline def render: Render[P] = {
     val (props, children) = rawModifiers
     component.applyGeneric(props)(children: _*)
   }
+
+  private def copyComponent(
+    newComponent: Js.Component[P, Null, CT]
+  ): GenericJsComponentAC[P, CT, U, A] =
+    new GenericJsComponentAC[P, CT, U, A] {
+      override protected def cprops: P                                = self.cprops
+      override val modifiers: Seq[japgolly.scalajs.react.vdom.TagMod] = self.modifiers
+      override protected val component                                = newComponent
+      override def addModifiers(modifiers: Seq[TagMod]): A = self.addModifiers(modifiers)
+    }
+
+  def withRef(ref: Ref.Handle[Js.RawMounted[P, Null]]): GenericJsComponentAC[P, CT, U, A] =
+    copyComponent(self.component.withRef(ref))
+
+  def withOptionalRef(
+    ref: Option[Ref.Handle[Js.RawMounted[P, Null]]]
+  ): GenericJsComponentAC[P, CT, U, A] =
+    copyComponent(self.component.withOptionalRef(ref))
+}
+
+trait GenericJsComponentF[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, F <: js.Object] { self =>
+  protected def cprops: P
+  protected val component: Js.ComponentWithFacade[P, Null, F, CT]
+
+  def rawProps: P                   = cprops
+  @inline def render: RenderF[P, F] = component.applyGeneric(rawProps)()
+
+  private def copyComponent(
+    newComponent: Js.ComponentWithFacade[P, Null, F, CT]
+  ): GenericJsComponentF[P, CT, U, F] =
+    new GenericJsComponentF[P, CT, U, F] {
+      override protected def cprops: P = self.cprops
+      override protected val component = newComponent
+    }
+
+  def withRef(ref: Ref.Handle[Js.RawMounted[P, Null] with F]): GenericJsComponentF[P, CT, U, F] =
+    copyComponent(self.component.withRef(ref))
+
+  def withOptionalRef(
+    ref: Option[Ref.Handle[Js.RawMounted[P, Null] with F]]
+  ): GenericJsComponentF[P, CT, U, F] =
+    copyComponent(self.component.withOptionalRef(ref))
+}
+
+trait GenericJsComponentCF[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F <: js.Object] {
+  self =>
+  protected def cprops: P
+  val children: CtorType.ChildrenArgs
+  def withChildren(children: CtorType.ChildrenArgs): A
+  protected val component: Js.ComponentWithFacade[P, Null, F, CT]
+
+  def rawProps: P                        = cprops
+  @inline def renderWith: RenderCF[P, F] = component.applyGeneric(rawProps)
+  @inline def render: RenderF[P, F]      = renderWith(children)
+
+  private def copyComponent(
+    newComponent: Js.ComponentWithFacade[P, Null, F, CT]
+  ): GenericJsComponentCF[P, CT, U, A, F] =
+    new GenericJsComponentCF[P, CT, U, A, F] {
+      override protected def cprops: P = self.cprops
+      override val children            = self.children
+      override def withChildren(children: CtorType.ChildrenArgs): A = self.withChildren(children)
+      override protected val component = newComponent
+    }
+
+  def withRef(
+    ref: Ref.Handle[Js.RawMounted[P, Null] with F]
+  ): GenericJsComponentCF[P, CT, U, A, F] =
+    copyComponent(self.component.withRef(ref))
+
+  def withOptionalRef(
+    ref: Option[Ref.Handle[Js.RawMounted[P, Null] with F]]
+  ): GenericJsComponentCF[P, CT, U, A, F] =
+    copyComponent(self.component.withOptionalRef(ref))
+}
+
+trait GenericJsComponentAF[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F <: js.Object]
+    extends PassthroughA[P] { self =>
+  protected val component: Js.ComponentWithFacade[P, Null, F, CT]
+  def addModifiers(modifiers: Seq[TagMod]): A
+
+  @inline def render: RenderF[P, F] = component.applyGeneric(rawProps)()
+
+  private def copyComponent(
+    newComponent: Js.ComponentWithFacade[P, Null, F, CT]
+  ): GenericJsComponentAF[P, CT, U, A, F] =
+    new GenericJsComponentAF[P, CT, U, A, F] {
+      override protected def cprops: P                                = self.cprops
+      override val modifiers: Seq[japgolly.scalajs.react.vdom.TagMod] = self.modifiers
+      override protected val component                                = newComponent
+      override def addModifiers(modifiers: Seq[TagMod]): A = self.addModifiers(modifiers)
+    }
+
+  def withRef(
+    ref: Ref.Handle[Js.RawMounted[P, Null] with F]
+  ): GenericJsComponentAF[P, CT, U, A, F] =
+    copyComponent(self.component.withRef(ref))
+
+  def withOptionalRef(
+    ref: Option[Ref.Handle[Js.RawMounted[P, Null] with F]]
+  ): GenericJsComponentAF[P, CT, U, A, F] =
+    copyComponent(self.component.withOptionalRef(ref))
+}
+
+trait GenericJsComponentACF[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F <: js.Object]
+    extends PassthroughAC[P] { self =>
+  protected val component: Js.ComponentWithFacade[P, Null, F, CT]
+  def addModifiers(modifiers: Seq[TagMod]): A
+
+  @inline def render: RenderF[P, F] = {
+    val (props, children) = rawModifiers
+    component.applyGeneric(props)(children: _*)
+  }
+
+  private def copyComponent(
+    newComponent: Js.ComponentWithFacade[P, Null, F, CT]
+  ): GenericJsComponentACF[P, CT, U, A, F] =
+    new GenericJsComponentACF[P, CT, U, A, F] {
+      override protected def cprops: P                                = self.cprops
+      override val modifiers: Seq[japgolly.scalajs.react.vdom.TagMod] = self.modifiers
+      override protected val component                                = newComponent
+      override def addModifiers(modifiers: Seq[TagMod]): A = self.addModifiers(modifiers)
+    }
+
+  def withRef(
+    ref: Ref.Handle[Js.RawMounted[P, Null] with F]
+  ): GenericJsComponentACF[P, CT, U, A, F] =
+    copyComponent(self.component.withRef(ref))
+
+  def withOptionalRef(
+    ref: Option[Ref.Handle[Js.RawMounted[P, Null] with F]]
+  ): GenericJsComponentACF[P, CT, U, A, F] =
+    copyComponent(self.component.withOptionalRef(ref))
 }

--- a/common/src/main/scala/react/common/package.scala
+++ b/common/src/main/scala/react/common/package.scala
@@ -4,8 +4,7 @@ import japgolly.scalajs.react.CtorType
 import japgolly.scalajs.react.vdom.VdomElement
 import japgolly.scalajs.react.vdom.VdomNode
 import japgolly.scalajs.react.component.Generic
-import japgolly.scalajs.react.component.Js.RawMounted
-import japgolly.scalajs.react.component.Js.UnmountedWithRawType
+import japgolly.scalajs.react.component.Js._
 import japgolly.scalajs.react.component.Scala
 import japgolly.scalajs.react.vdom.TagMod
 import react.common.syntax.AllSyntax
@@ -65,10 +64,12 @@ package object common extends AllSyntax {
   // End Scala Components
 
   // Begin JS Components
-  type RenderFn[P]             = Generic.Unmounted[P, Unit]
-  type Render[P <: js.Object]  = UnmountedWithRawType[P, Null, RawMounted[P, Null]]
-  type RenderFnC[P]            = CtorType.ChildrenArgs => RenderFn[P]
-  type RenderC[P <: js.Object] = CtorType.ChildrenArgs => Render[P]
+  type RenderFn[P]                              = Generic.Unmounted[P, Unit]
+  type Render[P <: js.Object]                   = Unmounted[P, Null]
+  type RenderF[P <: js.Object, F <: js.Object]  = UnmountedWithFacade[P, Null, F]
+  type RenderFnC[P]                             = CtorType.ChildrenArgs => RenderFn[P]
+  type RenderC[P <: js.Object]                  = CtorType.ChildrenArgs => Render[P]
+  type RenderCF[P <: js.Object, F <: js.Object] = CtorType.ChildrenArgs => RenderF[P, F]
 
   type GenericFnComponentP[P <: js.Object]      = GenericFnComponent[P, CtorType.Props, Unit]
   type GenericFnComponentPC[P <: js.Object, A]  =
@@ -83,6 +84,15 @@ package object common extends AllSyntax {
   type GenericComponentPA[P <: js.Object, A]  = GenericJsComponentA[P, CtorType.Props, Unit, A]
   type GenericComponentPAC[P <: js.Object, A] =
     GenericJsComponentAC[P, CtorType.PropsAndChildren, Unit, A]
+
+  type GenericComponentPF[P <: js.Object, F <: js.Object]      =
+    GenericJsComponentF[P, CtorType.Props, Unit, F]
+  type GenericComponentPCF[P <: js.Object, A, F <: js.Object]  =
+    GenericJsComponentCF[P, CtorType.PropsAndChildren, Unit, A, F]
+  type GenericComponentPAF[P <: js.Object, A, F <: js.Object]  =
+    GenericJsComponentAF[P, CtorType.Props, Unit, A, F]
+  type GenericComponentPACF[P <: js.Object, A, F <: js.Object] =
+    GenericJsComponentACF[P, CtorType.PropsAndChildren, Unit, A, F]
 
   implicit class GenericFnComponentPCOps[P <: js.Object, A](val c: GenericFnComponentPC[P, A])
       extends AnyVal {

--- a/common/src/main/scala/react/common/syntax/package.scala
+++ b/common/src/main/scala/react/common/syntax/package.scala
@@ -180,7 +180,7 @@ package syntax {
   }
 
   trait VdomSyntax    {
-    // Fn to VdomNode conversions
+    // FnComponent to VdomNode conversions
     implicit def GenericFnComponentP2VdomNode[P <: js.Object](
       p: GenericFnComponentP[P]
     ): VdomNode =
@@ -201,7 +201,7 @@ package syntax {
     ): VdomNode =
       p.render
 
-    // Component 2 VdomNode
+    // Component 2 VdomNode conversions
     implicit def GenericComponentP2VdomNode[P <: js.Object](
       p: GenericComponentP[P]
     ): VdomNode =
@@ -222,6 +222,28 @@ package syntax {
     ): VdomNode =
       p.render
 
+    // Facade component 2 VdomNode conversions
+    implicit def GenericComponentPF2VdomNode[P <: js.Object, F <: js.Object](
+      p: GenericComponentPF[P, F]
+    ): VdomNode =
+      p.render
+
+    implicit def GenericComponentPCF2VdomNode[P <: js.Object, F <: js.Object](
+      p: GenericComponentPCF[P, _, F]
+    ): VdomNode =
+      p.render
+
+    implicit def GenericComponentPAF2VdomNode[P <: js.Object, F <: js.Object](
+      p: GenericComponentPAF[P, _, F]
+    ): VdomNode =
+      p.render
+
+    implicit def GenericComponentPACF2VdomNode[P <: js.Object, F <: js.Object](
+      p: GenericComponentPACF[P, _, F]
+    ): VdomNode =
+      p.render
+
+    // FnComponent to js.UndefOr[VdomNode] conversions
     implicit def GenericFnComponentP2UndefVdomNode[P <: js.Object](
       p: GenericFnComponentP[P]
     ): js.UndefOr[VdomNode] =
@@ -242,6 +264,7 @@ package syntax {
     ): js.UndefOr[VdomNode] =
       p.render: VdomNode
 
+    // Component to js.UndefOr[VdomNode] conversions
     implicit def GenericComponentP2UndefVdomNode[P <: js.Object](
       p: GenericComponentP[P]
     ): js.UndefOr[VdomNode] =
@@ -261,6 +284,28 @@ package syntax {
       p: GenericComponentPAC[P, _]
     ): js.UndefOr[VdomNode] =
       p.render: VdomNode
+
+    // Facade Component to js.UndefOr[VdomNode] conversions
+    implicit def GenericComponentPF2UndefVdomNode[P <: js.Object, F <: js.Object](
+      p: GenericComponentPF[P, F]
+    ): js.UndefOr[VdomNode] =
+      p.render: VdomNode
+
+    implicit def GenericComponentPCF2UndefVdomNode[P <: js.Object, F <: js.Object](
+      p: GenericComponentPCF[P, _, F]
+    ): js.UndefOr[VdomNode] =
+      p.render: VdomNode
+
+    implicit def GenericComponentPAF2UndefVdomNode[P <: js.Object, F <: js.Object](
+      p: GenericComponentPAF[P, _, F]
+    ): js.UndefOr[VdomNode] =
+      p.render: VdomNode
+
+    implicit def GenericComponentPACF2UndefVdomNode[P <: js.Object, F <: js.Object](
+      p: GenericComponentPACF[P, _, F]
+    ): js.UndefOr[VdomNode] =
+      p.render: VdomNode
+
     // End VdomNode conversions
   }
 }


### PR DESCRIPTION
- Handle JS components with facades.
- Allow `.withRef` and `.withOptionalRef` on JS components.
- Simplify some types.